### PR TITLE
Better error reporting for wrong values passed in show_elements

### DIFF
--- a/R/ggvenn.R
+++ b/R/ggvenn.R
@@ -196,10 +196,10 @@ prepare_venn_data <- function(data, columns = NULL,
       columns = data %>% select_if(is.logical) %>% names
     }
     if (!identical(show_elements, FALSE)) {
-      stopifnot(is.character(show_elements))
-      show_elements <- show_elements[[1]]
-      if (!(show_elements %in% names(data))) {
-        stop("`show_elements` should be one column name of the data frame")
+      if (!all(show_elements %in% names(data), is.character(show_elements))) {
+        stop("Value ", deparse(show_elements), 
+             " in `show_elements` does not correspond to any column name of the data frame.",
+             call. = FALSE)
       }
     }
     if (length(columns) == 2) {

--- a/R/ggvenn.R
+++ b/R/ggvenn.R
@@ -196,7 +196,11 @@ prepare_venn_data <- function(data, columns = NULL,
       columns = data %>% select_if(is.logical) %>% names
     }
     if (!identical(show_elements, FALSE)) {
-      if (!all(show_elements %in% names(data), is.character(show_elements))) {
+      if (!{
+        if (is.character(show_elements)) {
+          show_elements <- show_elements[[1]]
+          show_elements %in% names(data)
+          } else { FALSE }}) {
         stop("Value ", deparse(show_elements), 
              " in `show_elements` does not correspond to any column name of the data frame.",
              call. = FALSE)


### PR DESCRIPTION
# Problem
The code:
```r
 d <- tibble(value   = c(1,     2,     3,     5,     6,     7,     8,     9),
             `Set 1` = c(TRUE,  FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE),
             `Set 2` = c(TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE),
             `Set 3` = c(TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE),
             `Set 4` = c(FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE))
ggvenn(d, c("Set 1", "Set 2"), show_elements = TRUE)
```
Would return error message reflecting `is.character` call evaluating to `FALSE` in `stopifnot`. `stopifnot` is only a convenience function for call:

```r
if(!all(conditions)) stop(any message)
```

receiving notification that `is.character` returns FALSE the user could be tempted to run
```r
ggvenn(d, c("Set 1", "Set 2"), show_elements = "TRUE")
```
This is unhelpful as the *real* problem is associated with the value not corresponding to the data frame column.

# Desired behaviour
Informative error message leading to solution irrespectively of whether failure happened at `is.character` or later

# Proposed fix
Evaluate the required condition and then return consistent, informative error message.

--- 
For a more robust argument checking the [`checkmate'](https://github.com/mllg/checkmate) provides a better well-painted alternative.