### PR TITLE
Add `padding` argument to `ggvenn` to address label truncation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggvenn
 Title: Draw Venn Diagram by 'ggplot2'
-Version: 0.1.14
+Version: 0.1.15
 Authors@R: person(given = "Linlin", family = "Yan",
                   role = c("aut", "cre"),
                   email = "yanlinlin82@gmail.com",
@@ -14,10 +14,12 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 RoxygenNote: 7.3.1
 Depends: ggplot2
-Imports: dplyr, grid, scales
 Suggests: 
     testthat (>= 3.0.0)
-Config/testthat/edition: 3
-Roxygen: list(markdown = TRUE)
 Imports: 
+    dplyr, 
+    grid, 
+    scales,
     lifecycle
+Roxygen: list(markdown = TRUE)
+Config/testthat/edition: 3

--- a/R/ggvenn.R
+++ b/R/ggvenn.R
@@ -23,6 +23,7 @@
 #' @param show_outside Show outside elements (not belongs to any set).
 #' @param auto_scale Allow automatically resizing circles according to element counts.
 #' @param comma_sep Whether to use comma as separator for displaying numbers.
+#' @param padding Padding for the plot. Change this to allow longer labels to be displayed.
 #' @return The ggplot object to print or save to file.
 #' @examples
 #' library(ggvenn)
@@ -82,7 +83,8 @@ ggvenn <- function(data, columns = NULL,
                    count_column = NULL,
                    show_outside = c("auto", "none", "always"),
                    auto_scale = FALSE,
-                   comma_sep=FALSE) {
+                   comma_sep=FALSE,
+                   padding = 0.2) {
   show_outside <- match.arg(show_outside)
   if (lifecycle::is_present(show_percentage)) {
     lifecycle::deprecate_soft("0.1.11", "ggvenn::ggvenn(show_percentage = )", "ggvenn::ggvenn(show_stats = )")
@@ -126,6 +128,8 @@ ggvenn <- function(data, columns = NULL,
   }
   g <- g +
     scale_fill_manual(values = fill_color) +
+    scale_x_discrete(expand = expansion(mult = c(padding, padding))) +
+    scale_y_discrete(expand = expansion(mult = c(padding, padding))) +
     guides(fill = "none") +
     coord_fixed() +
     theme_void()


### PR DESCRIPTION
This commit introduces a new `padding` argument to the `ggvenn` function. This allows users to control the padding around the Venn diagram, which is particularly useful for addressing the issue of truncated labels, as reported in #25 and #40.

The default value for `padding` is 0.2. Increasing this value will add more padding around the diagram, preventing labels from being cut off when they are too long.

This new argument provides users with more control over the appearance of their Venn diagrams and improves the overall usability of the `ggvenn` package, directly addressing the concerns raised in issue #25 and #40.

**Resolves:** #25 and #40