### PR TITLE
Count outside elements in percentages in show_outside=None

### DIFF
--- a/R/ggvenn.R
+++ b/R/ggvenn.R
@@ -553,11 +553,7 @@ prepare_venn_data <- function(data, columns = NULL,
   } else {
     stop("`data` should be either a list or a data.frame")
   }
-  if ((show_outside == "none") || (show_outside == "auto" && df_text$n[[nrow(df_text)]] == 0)) {
-    if (df_text$n[[nrow(df_text)]] > 0)
-      warning("Although not display in plot, outside elements are still count in percentages.")
-    df_text <- df_text[-nrow(df_text), ]
-  }
+
   if (!show_elements) {
     fmt_count <- "%d"
     fmt_percentage <- sprintf("%%.%df%%%%", digits)
@@ -589,8 +585,13 @@ prepare_venn_data <- function(data, columns = NULL,
       },
       TRUE ~ ""
     ))
-    
-    }
+  }
+  if ((show_outside == "none") || (show_outside == "auto" && df_text$n[[nrow(df_text)]] == 0)) {
+    if (df_text$n[[nrow(df_text)]] > 0)
+      warning("Although not display in plot, outside elements are still count in percentages.")
+    df_text <- df_text[-nrow(df_text), ]
+  }
+
   list(shapes = df_shape, texts = df_text, labels = df_label, segs = df_seg)
 }
 


### PR DESCRIPTION
Move the code that removes the outsides elements after the percentages' computation to align with the warning message `Although not display in plot, outside elements are still count in percentages.`

This pr fixes issue #52 